### PR TITLE
댓글 도메인 ResponseDto 사용 및 뉴스 도메인 listing 에러 코드 수정

### DIFF
--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -137,8 +137,9 @@ function getComments() {
                 let modifiedDate = comment.modifiedAt;
                 let time = time2str(new Date(modifiedDate));
                 let content = comment.content;
-                let username = comment.user.username;
-                addHTML(commentId, time, content, username);
+                let username = comment.profileResponseDto.username;
+                let nickname = comment.profileResponseDto.nickname;
+                addHTML(commentId, time, content, username, nickname);
             }
         }
     })
@@ -200,14 +201,15 @@ function getSortedComments(direction) {
                 let createdDate = comment.createdAt;
                 let time = time2str(new Date(createdDate));
                 let content = comment.content;
-                let username = comment.user.username;
-                addHTML(commentId, time, content, username);
+                let username = comment.profileResponseDto.username;
+                let nickname = comment.profileResponseDto.nickname;
+                addHTML(commentId, time, content, username, nickname);
             }
         }
     })
 }
 
-function addHTML(commentId, time, content, username) {
+function addHTML(commentId, time, content, username, nickname) {
 
     let currentLoginUserName = $.ajax({
         async: false,
@@ -228,7 +230,7 @@ function addHTML(commentId, time, content, username) {
                         <div class="media-content">
                             <div class="content">
                                 <p>
-                                    <strong>nickname</strong> <small>@${username}</small> <small>${time}</small>
+                                    <strong>${nickname}</strong> <small>@${username}</small> <small>${time}</small>
                                     <br>
                                     <span id="${commentId}-content">${content}</span>
                                 </p>
@@ -260,7 +262,7 @@ function addHTML(commentId, time, content, username) {
                         <div class="media-content">
                             <div class="content">
                                 <p>
-                                    <strong>nickname</strong> <small>@${username}</small> <small>${time}</small>
+                                    <strong>${nickname}</strong> <small>@${username}</small> <small>${time}</small>
                                     <br>
                                     ${content}
                                 </p>
@@ -336,7 +338,7 @@ function updateLike(commentId) {
             success: function(response) {
                 let likesCount = $.ajax({
                     async: false,
-                    url: `/api/user/likes/${commentId}`,
+                    url: `/api/user/likes/count/${commentId}`,
                     type: "GET",
                     dataType: "text"
                 }).responseText;

--- a/static/js/listing.js
+++ b/static/js/listing.js
@@ -10,7 +10,7 @@ const listing = () => {
         url: '/api/news', // 테스트용 url
         data: {},
         success: function (response) {
-            let news_list = response['body']['result']['newsTableList'];
+            let news_list = response['newsTableList'];
             $('#cards-box').empty();
             for (let i = 0; i < news_list.length; i++) {
                 // 서버로 부터 받은 뉴스 리스트의 각 뉴스에 접근해 관련 정보를 받는다.


### PR DESCRIPTION
[댓글 도메인]

GET요청을 하여 데이터를 받는 함수에 ResponseDto를 활용하는 방식으로 코드를 수정했습니다.

[뉴스 도메인]

index 페이지에서 뉴스가 리스팅이 되지 않는 에러를 listgin.js 코드를 수정함으로써 해결했습니다.