### PR TITLE
고객관리 페이지 개편

### DIFF
--- a/static/js/basic.js
+++ b/static/js/basic.js
@@ -44,7 +44,7 @@ function navIcon() {
 		`
 	} else {
 		tempHtml=`
-			<a class="profile_iconsupport_icon" onclick="window.location.href = '/NewsCommunity-fFinal/support.html'"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
+			<a class="support_icon" onclick="window.location.href = '/NewsCommunity-fFinal/support.html'"><i class="fa fa-question-circle-o" aria-hidden="true"></i></a>
 			<a class="login_icon" onclick="window.location.href = '/NewsCommunity-fFinal/login.html'"><i class="fa-solid fa-arrow-right-to-bracket"></i></a>
 		`
 	}

--- a/static/js/support.js
+++ b/static/js/support.js
@@ -1,30 +1,29 @@
 history.scrollRestoration = "manual"
 
 $(document).ready(function () {
-    get_list();
+    getList();
 });
 
-function toggle_writing() {
+function toggleWriting() {
     $("#sumbit_toggle").toggle();
     $("#input_text").val('');
     $("#input_name").val('');
     $("#input_title").val('');
 }
 
-function toggle_myid(num) {
+function toggleMyId(num) {
     let buildID = '#contentsbox-' + num;
     $(buildID).toggle();
 }
 
-function submit_content() {
-    let newName = $("#input_name").val();
+function submitContent() {
     let newTitle = $("#input_title").val();
     let newText = $("#input_text").val();
-    let data = {"username": newName, "post_title": newTitle, "post_content": newText};
-    if (newName != null && newTitle != null && newText != null) {
+    let data = {"post_title": newTitle, "post_content": newText};
+    if (newTitle != null && newText != null) {
         $.ajax({
             type: "POST",
-            url: `/api/supports/`,
+            url: `/api/user/supports/`,
             contentType: "application/json",
             data: JSON.stringify(data),
             success: function (response) {
@@ -34,45 +33,62 @@ function submit_content() {
     }
 }
 
-function edit_contents(num) {
-    let setContentsID = '#contents-' + num;
+function editContent(contentIdx) {
+    let getToken = localStorage.getItem('IllllIlIII_hid');
+    let setContentsID = '#contents-' + contentIdx;
+    let setUsername = '#username-' + contentIdx;
+    let getUsername = $(setUsername).text();
 
-    if ($('.edit_btn').html() == "수정") { //수정 시작
-        $(setContentsID).attr("readonly", false);
-        $('.edit_btn').html('저장');
-    } else { //저장버튼 클릭 후
-        $('.edit_btn').html('수정'); //저장 버튼 클릭시 수정으로 글씨 변경 및 서버 전송
-        $(setContentsID).attr("readonly", true);
+    if(getToken==getUsername){
+        if ($('.edit_btn').html() == "수정") { //수정 시작
+            alert('수정을 시작합니다');
+            $(setContentsID).attr("readonly", false);
+            $('.edit_btn').html('저장');
+        } else { //저장버튼 클릭 후
+            $('.edit_btn').html('수정'); //저장 버튼 클릭 => 수정으로 글씨 변경 및 서버 전송
+            $(setContentsID).attr("readonly", true);
+            let contents = $(setContentsID).val();
+            let data = {"post_content": contents};
+            console.log(data)
+            $.ajax({
+                type: "PUT",
+                url: `/api/user/supports/${contentIdx}`,
+                contentType: "application/json",
+                data: JSON.stringify(data),
+                success: function (response) {
+                    alert('수정 완료');
+                }
+            });
+        }
+    }else{
+        alert("권한이 없습니다.")
+    }
 
-        let contents = $(setContentsID).val();
-        let data = {"post_content": contents};
-        console.log(data)
+
+}
+
+function deleteContent(contentIdx){
+    let getToken = localStorage.getItem('IllllIlIII_hid');
+    let setUsername = '#username-' + contentIdx;
+    let getUsername = $(setUsername).text();
+
+    if(getToken==getUsername){
+
         $.ajax({
-            type: "PUT",
-            url: `/api/supports/${num}`,
+            type: "DELETE",
+            url: `/api/user/supports/${contentIdx}`,
             contentType: "application/json",
-            data: JSON.stringify(data),
             success: function (response) {
-                alert('수정 완료');
+                window.location.reload()
+                alert("삭제완료")
             }
         });
+    }else{
+        alert("권한이 없습니다.")
     }
 }
 
-function delete_content(contentIdx){
-    console.log();
-    $.ajax({
-        type: "DELETE",
-        url: `/api/supports/${contentIdx}`,
-        contentType: "application/json",
-        success: function (response) {
-            window.location.reload()
-            alert("삭제완료")
-        }
-    });
-}
-
-function get_list() {
+function getList() {
     $.ajax({
         url: '/api/supports',
         type: 'GET',
@@ -92,9 +108,9 @@ function get_list() {
                             <tr class="tr_title" id="open_it">
                                 <th scope="row">${idx}</th>
                                 <td class="name">
-                                    <a onclick="toggle_myid(${idx})"> ${getTitle} </a>
+                                    <a onclick="toggleMyId(${idx})"> ${getTitle} </a>
                                 </td>
-                                <td>${getUsername}</td>
+                                <td id="username-${idx}">${getUsername}</td>
                                 <td>${createdYYMMDD}</td>
                             </tr>
                             <tr id="contentsbox-${idx}" class="content_box" style="display: none;">
@@ -102,7 +118,7 @@ function get_list() {
                                     <div >
                                         <div class="content_btn_div" style="display: flex; justify-items: right;">
                                             <div class="content_btn_sub_div" style="margin-left: auto; padding-bottom: 10px;">
-                                                <button onclick="delete_content(${idx})" type="button" class="submit_btn btn btn-light">게시글 삭제하기</button>
+                                                <button onclick="deleteContent(${idx})" type="button" class="submit_btn btn btn-light">게시글 삭제하기</button>
                                             </div>
                                         </div>
                                         <div class="input-group mb-3" >
@@ -118,8 +134,8 @@ function get_list() {
 
                                         <div class="content_btn_div" style="display: flex; justify-items: right;">
                                             <div class="content_btn_sub_div" style="margin-left: auto;">
-                                                <button onclick="edit_contents(${idx})" type="button" class="edit_btn btn btn-light">수정</button>
-                                                <button onclick="toggle_myid(${idx})" type="button" class="submit_btn btn btn-light">닫기</button>
+                                                <button onclick="editContent(${idx})" type="button" class="edit_btn btn btn-light">수정</button>
+                                                <button onclick="toggleMyId(${idx})" type="button" class="submit_btn btn btn-light">닫기</button>
                                             </div>
                                         </div>
 

--- a/static/js/support.js
+++ b/static/js/support.js
@@ -5,10 +5,15 @@ $(document).ready(function () {
 });
 
 function toggleWriting() {
-    $("#sumbit_toggle").toggle();
-    $("#input_text").val('');
-    $("#input_name").val('');
-    $("#input_title").val('');
+    let getToken = localStorage.getItem('IllllIlIII_hid');
+    if (getToken == null){
+        alert('작성은 로그인 후 가능합니다')
+    } else {
+        $("#sumbit_toggle").toggle();
+        $("#input_text").val('');
+        $("#input_name").val('');
+        $("#input_title").val('');
+    }
 }
 
 function toggleMyId(num) {

--- a/static/js/support.js
+++ b/static/js/support.js
@@ -58,7 +58,7 @@ function editContent(contentIdx, countedTime) {
     if(getToken==getUsername){
         if ($(edit_btnID).html() == "수정") { //수정 시작
             if (countedTime>=1800){
-                alert('작성 한 후 30분이 지나서 수정이 불가합니다')
+                alert('일정 시간이 경과하여 수정이 불가합니다.')
             }else{
                 alert('수정을 시작합니다');
                 $(setContentsID).attr("readonly", false);
@@ -77,7 +77,7 @@ function editContent(contentIdx, countedTime) {
                 contentType: "application/json",
                 data: JSON.stringify(data),
                 success: function (response) {
-                    alert('수정 완료');
+                    alert('수정 완료되었습니다.');
                 }
             });
         }
@@ -92,7 +92,7 @@ function deleteContent(contentIdx,countedTime){
     let getUsername = $(setUsername).text();
     if(getToken==getUsername){
         if (countedTime>=1800) {
-            alert('작성 한 후 30분이 지나서 삭제가 불가합니다')
+            alert('일정 시간이 경과하여 삭제가 불가합니다.')
         }else{
             $.ajax({
                 type: "DELETE",
@@ -100,7 +100,7 @@ function deleteContent(contentIdx,countedTime){
                 contentType: "application/json",
                 success: function (response) {
                     window.location.reload()
-                    alert("삭제완료")
+                    alert("삭제 완료되었습니다.")
                 }
             });
         }
@@ -124,9 +124,11 @@ function convertList(){
     let urlForMe = '/api/user/supports/mine';
     if(currentUrl === urlForAll){
         currentUrl = urlForMe;
+        $('.onlymine_btn').html("전체 게시물 확인하기");
     }
     else if(currentUrl === urlForMe){
         currentUrl = urlForAll;
+        $('.onlymine_btn').html("내가 쓴 게시글만 확인하기");
     }
     defaultURLforGetList = currentUrl;
     getList()

--- a/static/js/support.js
+++ b/static/js/support.js
@@ -24,8 +24,15 @@ function toggleMyId(num) {
 function submitContent() {
     let newTitle = $("#input_title").val();
     let newText = $("#input_text").val();
-    let data = {"post_title": newTitle, "post_content": newText};
-    if (newTitle != null && newText != null) {
+    let newEmail = $("#input_email").val();
+    let data = {"post_title": newTitle, "post_content": newText, "email":newEmail};
+    let regEmail = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
+
+    if (regEmail.test(newEmail) !== true) {
+        return alert('이메일이 형식에 맞지 않습니다');
+    }
+
+    if (newTitle != '' && newText != '') {
         $.ajax({
             type: "POST",
             url: `/api/user/supports/`,
@@ -35,6 +42,8 @@ function submitContent() {
                 window.location.reload()
             }
         });
+    }else{
+        alert('빠진 곳이 없는지 확인해주세요!\n전부 입력해주셔야 등록이 가능합니다');
     }
 }
 

--- a/static/js/support.js
+++ b/static/js/support.js
@@ -133,8 +133,14 @@ function convertList(){
 }
 
 function getList() {
+    let getToken = localStorage.getItem('IllllIlIII_hid');
+    if (getToken != null){
+        $('.onlymine_btn').show();
+    }else {
+        $('.onlymine_btn').hide();
+    }
     $.ajax({
-        url: '/api/supports',
+        url: defaultURLforGetList,
         type: 'GET',
         success: function (result) {
             $('#table_body').empty();
@@ -150,11 +156,9 @@ function getList() {
                 let createdWithTime = getCreatedAt.slice(0, 10) + ' ' + getCreatedAt.slice(11, 19);
 
                 let myhtml = `
-                            <tr class="tr_title" id="open_it">
+                            <tr class="tr_title" onclick="toggleMyId(${idx})">
                                 <th scope="row">${idx}</th>
-                                <td class="name">
-                                    <a onclick="toggleMyId(${idx})"> ${getTitle} </a>
-                                </td>
+                                <td class="name">${getTitle}</td>
                                 <td id="username-${idx}">${getUsername}</td>
                                 <td>${createdYYMMDD}</td>
                             </tr>
@@ -173,7 +177,7 @@ function getList() {
                                         <div class="input-group mb-3">
                                             <span class="input-group-text" style="background-color: #f7f7f7">작성 내용</span>
                                             <span class="form-control" style="background-color: white">
-                                                <textarea id="contents-${idx}" style="border: none;height:20rem;" readonly class="form-control text_area">${getContent}</textarea>
+                                                <textarea id="contents-${idx}" style="border: none;" readonly class="form-control readmodify_textarea">${getContent}</textarea>
                                             </span>
                                         </div>
 

--- a/static/js/support.js
+++ b/static/js/support.js
@@ -50,6 +50,7 @@ function submitContent() {
 function editContent(contentIdx, countedTime) {
     let getToken = localStorage.getItem('IllllIlIII_hid');
     let setContentsID = '#contents-' + contentIdx;
+    let edit_btnID = '#edit_btn-' + contentIdx;
     let setUsername = '#username-' + contentIdx;
     let getUsername = $(setUsername).text();
 

--- a/static/support.css
+++ b/static/support.css
@@ -107,11 +107,12 @@ textarea{
     background-color: lightgray;
 }
 
-.onlymine_btn{
-    border: darkgreen solid 2px;
-}
-button:active, button:focus{
+btns:active, btns:focus{
     outline: 0 !important;
     border: none !important;
+    box-shadow: none !important;
+}
+.onlymine_btn, .onlymine_btn:focus, .onlymine_btn:active{
+    border: darkgreen solid 2px;
     box-shadow: none !important;
 }

--- a/static/support.css
+++ b/static/support.css
@@ -98,7 +98,8 @@ textarea{
     border: 1px solid lightgray;
 }
 .tr_title:hover {
-    background-color: rgba(142,185,139,0.48)
+    background-color: rgba(142,185,139,0.48);
+    cursor:pointer;
 }
 
 .row_title{

--- a/static/support.css
+++ b/static/support.css
@@ -18,7 +18,7 @@ table {
     border-radius: 5px;
 }
 thead{
-    background-color: white;
+    background-color: lightgray;
 }
 
 
@@ -43,10 +43,16 @@ th:nth-child(4) {
 .name {
     text-align: left;
 }
-.text_area {
-    background-color: #FFF !important;
-}
 
+textarea{
+    height:20rem;
+}
+.readmodify_textarea, .readmodify_textarea:focus, .readmodify_textarea:active, textarea:focus{
+    background-color: #FFF !important;
+    outline: 0 !important;
+    border: none !important;
+    box-shadow: none !important;
+}
 
 .writing_button_div {
     display: flex;
@@ -57,6 +63,7 @@ th:nth-child(4) {
     margin-left: auto;
 }
 
+
 .submit {
     display: flex;
     justify-content: center;
@@ -65,13 +72,16 @@ th:nth-child(4) {
 .submit_card {
     padding: 20px;
     margin-bottom: 30px;
-    width: 80%;
+    width: 75%;
     display: none;
+    background-color: lightgray;
 }
+
 
 .input-group-text {
     padding-left: 20px;
     padding-right: 20px;
+    background-color: #f7f7f7;
 }
 
 .content_btn_div {
@@ -91,3 +101,16 @@ th:nth-child(4) {
     background-color: rgba(142,185,139,0.48)
 }
 
+.row_title{
+    font-weight: bold;
+    background-color: lightgray;
+}
+
+.onlymine_btn{
+    border: darkgreen solid 2px;
+}
+button:active, button:focus{
+    outline: 0 !important;
+    border: none !important;
+    box-shadow: none !important;
+}

--- a/support.html
+++ b/support.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Support 페이지</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
           integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
     <!-- jQuery -->
@@ -11,17 +11,20 @@
     <!--my Css files-->
     <link rel="stylesheet" type="text/css" href="static/reset.css">
     <link rel="stylesheet" type="text/css" href="static/base.css">
-    <link rel="stylesheet" type="text/css" href="static/support.css">
 
     <!-- Font Awesome CSS -->
     <script src="https://kit.fontawesome.com/f6788aacd4.js" crossorigin="anonymous"></script>
+
     <!-- Googole Font -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rubik+Mono+One&family=Do+Hyeon&family=IBM+Plex+Sans+KR:wght@300;400;500&display=swap"
           rel="stylesheet">
+
     <!-- Bulma CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
+    <link rel="stylesheet" type="text/css" href="static/support.css">
+
     <!--custom file-->
     <script src="/NewsCommunity-fFinal/static/js/basic.js"></script>
     <script type="text/javascript" src="/static/js/support.js"></script>
@@ -47,15 +50,20 @@
                     문의/건의
                 </div>
                 <div class="card-body">
+                    <div style="float:left;">
                     질문 / 의견 / 건의 / 버그 제보 글을 작성해주세요
-                    <br>게시글 수정과 삭제는 본인만 가능합니다
+                    <br>게시글은 로그인 후 작성이 가능합니다
+                    </div>
+                    <div style="float:right;">
+                        <button onclick="convertList()" type="button" class="onlymine_btn writing_button btn btn-light" style="background-color: rgba(142,185,139,0.48);">내가 쓴 게시글만 확인하기</button>
+                    </div>
                 </div>
             </div>
 
 
             <table class="table table-borderless">
                 <thead class="table table-sm">
-                <tr style="background-color: #f7f7f7">
+                <tr class="row_title" style="background-color: #f7f7f7">
                     <th scope="col">번호</th>
                     <th scope="col">제목</th>
                     <th scope="col">이름</th>
@@ -64,7 +72,7 @@
                 </thead>
                 <tbody id="table_body">
                 <!--여기에 삽입-->
-                <tr class="tr_title" id="open_it">
+                <tr class="tr_title">
                     <th scope="row"></th>
                     <td class="name">
                         <span>게시물이 없습니다. 게시물을 작성해주세요.</span>
@@ -85,15 +93,15 @@
     <div class="submit">
         <div class="card submit_card" id="sumbit_toggle">
             <div class="input-group mb-3">
-                <span class="input-group-text" style="background-color: #f7f7f7">제 목</span>
+                <span class="input-group-text">제&nbsp&nbsp&nbsp목</span>
                 <input id="input_title" type="text" class="form-control" aria-label="Sizing example input"
                        aria-describedby="inputGroup-sizing-default">
             </div>
-<!--            <div class="input-group mb-3">-->
-<!--                <span class="input-group-text" style="background-color: #f7f7f7">이 름</span>-->
-<!--                <input id="input_name" type="text" class="form-control" aria-label="Sizing example input"-->
-<!--                       aria-describedby="inputGroup-sizing-default">-->
-<!--            </div>-->
+            <div class="input-group mb-3">
+                <span class="input-group-text">e-mail</span>
+                <input id="input_email" type="text" class="form-control" aria-label="Sizing example input"
+                       aria-describedby="inputGroup-sizing-default" placeholder="이메일로 답변을 드립니다. 이메일 양식에 맞게 작성해주세요">
+            </div>
             <div class="mb-3">
                 <label class="form-label">문의 내역</label>
                 <textarea id="input_text" class="form-control" rows="3"></textarea>

--- a/support.html
+++ b/support.html
@@ -55,7 +55,7 @@
                     <br>게시글은 로그인 후 작성이 가능합니다
                     </div>
                     <div style="float:right;">
-                        <button onclick="convertList()" type="button" class="onlymine_btn writing_button btn btn-light" style="background-color: rgba(142,185,139,0.48);">내가 쓴 게시글만 확인하기</button>
+                        <button onclick="convertList()" type="button" class="onlymine_btn writing_button btn btns btn-light" style="background-color: rgba(142,185,139,0.48);">내가 쓴 게시글만 확인하기</button>
                     </div>
                 </div>
             </div>
@@ -84,7 +84,7 @@
             </table>
         </div>
         <div class="writing_button_div">
-            <button type="button" class="writing_button btn btn-light" id="writing_toggle" onclick="toggleWriting()">글쓰기
+            <button type="button" class="writing_button btn btns btn-light" id="writing_toggle" onclick="toggleWriting()">글쓰기
             </button>
         </div>
     </div>
@@ -108,8 +108,8 @@
             </div>
             <div class="content_btn_div">
                 <div class="content_btn_sub_div">
-                    <button onclick="toggleWriting()" type="button" class="cancle_btn btn btn-light">취소</button>
-                    <button onclick="submitContent()" type="button" class="submit_btn btn btn-light">제출</button>
+                    <button onclick="toggleWriting()" type="button" class="cancle_btn btn btns btn-light">취소</button>
+                    <button onclick="submitContent()" type="button" class="submit_btn btn btns btn-light">제출</button>
                 </div>
             </div>
         </div>

--- a/support.html
+++ b/support.html
@@ -41,12 +41,14 @@
 
     <div class="wraper">
         <div class="main">
+
             <div class="card">
                 <div class="card-header">
                     문의/건의
                 </div>
                 <div class="card-body">
                     질문 / 의견 / 건의 / 버그 제보 글을 작성해주세요
+                    <br>게시글 수정과 삭제는 본인만 가능합니다
                 </div>
             </div>
 
@@ -65,7 +67,7 @@
                 <tr class="tr_title" id="open_it">
                     <th scope="row"></th>
                     <td class="name">
-                        <span>게시물이 없습니다.       게시물을 작성해주세요.</span>
+                        <span>게시물이 없습니다. 게시물을 작성해주세요.</span>
                     </td>
                     <td></td>
                     <td></td>
@@ -74,7 +76,7 @@
             </table>
         </div>
         <div class="writing_button_div">
-            <button type="button" class="writing_button btn btn-light" id="writing_toggle" onclick="toggle_writing()">글쓰기
+            <button type="button" class="writing_button btn btn-light" id="writing_toggle" onclick="toggleWriting()">글쓰기
             </button>
         </div>
     </div>
@@ -87,24 +89,19 @@
                 <input id="input_title" type="text" class="form-control" aria-label="Sizing example input"
                        aria-describedby="inputGroup-sizing-default">
             </div>
-            <div class="input-group mb-3">
-                <span class="input-group-text" style="background-color: #f7f7f7">이 름</span>
-                <input id="input_name" type="text" class="form-control" aria-label="Sizing example input"
-                       aria-describedby="inputGroup-sizing-default">
-            </div>
-            <div class="input-group mb-3">
-                <span class="input-group-text" style="background-color: #f7f7f7" id="inputGroup-sizing-default">Email</span>
-                <input type="text" class="form-control" aria-label="Sizing example input"
-                       aria-describedby="inputGroup-sizing-default">
-            </div>
+<!--            <div class="input-group mb-3">-->
+<!--                <span class="input-group-text" style="background-color: #f7f7f7">이 름</span>-->
+<!--                <input id="input_name" type="text" class="form-control" aria-label="Sizing example input"-->
+<!--                       aria-describedby="inputGroup-sizing-default">-->
+<!--            </div>-->
             <div class="mb-3">
                 <label class="form-label">문의 내역</label>
                 <textarea id="input_text" class="form-control" rows="3"></textarea>
             </div>
             <div class="content_btn_div">
                 <div class="content_btn_sub_div">
-                    <button onclick="toggle_writing()" type="button" class="cancle_btn btn btn-light">취소</button>
-                    <button onclick="submit_content()" type="button" class="submit_btn btn btn-light">제출</button>
+                    <button onclick="toggleWriting()" type="button" class="cancle_btn btn btn-light">취소</button>
+                    <button onclick="submitContent()" type="button" class="submit_btn btn btn-light">제출</button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
[Feat]
- 버튼 클릭을 통해 내가 쓴 게시글만 열람가능한 기능 추가 했습니다. 비로그인 시에는 보이지 않습니다.
- 수정, 삭제에 따른 부작용 방지를 위해 생성 30분 이후에 수정 및 삭제 불가하도록 처리했습니다.
- 이메일 입력 시 양식에 맞게 입력하도록 정규표현식 추가했으며, 모든 요소(글 제목,내용) 입력해야 생성 가능하도록 했습니다
- 

[Fix]
- 수정버튼 클릭시 해당 게시물 이외 다른 게시물의 버튼까지 활성화 되는 오류 발견하여 수정했습니다.
- 선 적용된 bulma, bootstrap이 직접 작성한 css파일을 덮어쓰는 것을 발견하여 코드 삽입 순서를 변경했습니다.
- 게시글 제목을 눌러야 게시글 확인이 가능했는데, 글자수가 적은 경우 열기 힘들다는 점을 발견해서 전체 영역 클릭시 열람 가능하게 변경하였습니다. 해당 영역 클릭 시 포인터 커서로 변경되도록 적용했습니다.
- textarea 및 button 클릭 시 라이브러리 기본 css에서 적용되는 focus 효과가 발생하여, 제거하였습니다.
