### PR TITLE
FIX: 북마크 토글 실행 안되는 에러 해결 #56

### DIFF
--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -40,7 +40,7 @@ const detail_listing = () =>{
                                     <div id="bookmark" class="bookmark level-item">
                                         <div id="${post_id}">
                                             <a class="is-sparta" aria-label="bookmark"
-                                               onclick="toggle_bookmark(${post_id})">
+                                               onclick="toggleBookmark(${post_id})">
                                                                             <span class="icon is-small"><i class="icon_ fa fa-solid fa-bookmark-o"
                                                                                                            aria-hidden="true"></i></span>
                                             </a>
@@ -290,7 +290,7 @@ function bookmarked(post_id) {
                 let icon = bookmark_by_me ? "fa-bookmark" : "fa-bookmark-o"
                 let temp_html = `<div id="${post_id}" class="bookmark">
                                     <a class="level-item is-sparta" aria-label="bookmark"
-                                           onclick="toggle_bookmark(${post_id})">
+                                           onclick="toggleBookmark(${post_id})">
                                                     <span class="icon is-small"><i class="icon_ fa fa-solid ${icon}"
                                                                                    aria-hidden="true"></i></span>
                                     </a>
@@ -336,7 +336,7 @@ function toggle_like(comment_id) {
 }
 
 // 북마크, 북마크 취소
-function toggle_bookmark(post_id) {
+function toggleBookmark(post_id) {
     let $i_bookmark = $(`#${post_id} a[aria-label='bookmark']`).find("i")
     if ($i_bookmark.hasClass("fa-bookmark")) {
         $.ajax({


### PR DESCRIPTION
- onclick="toggle_bookmark(1fe4acda-d71e-41fb-91a2-4807c1)"
- -> onclick=toggle_bookmark("1fe4acda-d71e-41fb-91a2-4807c1")
- (")를 잘못 사용해 생긴 에러 해결
- 2022-07-15 02:08
- Fixed: https://github.com/2022-Harmony/NewsCommunity-fFinal/issues/56