### PR TITLE
Feat: 댓글 작성시 공백 비허용, 글자 수 제한 기능 추가

### DIFF
--- a/detail.html
+++ b/detail.html
@@ -78,7 +78,7 @@
         <div class="media-content">
             <div class="field">
                 <p class="control">
-                    <textarea id="comment" class="textarea" placeholder="의견을 남겨주세요"></textarea>
+                    <textarea id="comment" class="textarea" placeholder="의견을 남겨주세요" onkeyup="checkCommentByte(this)"></textarea>
                 </p>
             </div>
             <nav class="level">

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -87,6 +87,27 @@ function getNewsId() {
     return newsId;
 }
 
+// 댓글 입력창에서 글자 수 제한을 바이트 단위로 체크하는 함수
+function checkCommentByte(obj) {
+    const maxByte = 500;
+    const content = obj.value;
+    const contentLength = content.length;
+
+    let totalByte = 0;
+    for (let i=0; i<contentLength; i++) {
+        const eachChar = content.charAt(i);
+        const uniChar = escape(eachChar);
+        if (uniChar.length > 4) {
+            totalByte += 2;
+        } else {
+            totalByte += 1;
+        }
+    }
+    if (totalByte > maxByte) {
+        alert("최대 글자 허용 길이를 초과하셨습니다.");
+    }
+}
+
 // 댓글 작성 함수
 function postComment() {
     let content = $('#comment').val();
@@ -94,6 +115,10 @@ function postComment() {
     let data = {
         "content": content,
         "newsId": newsId
+    }
+    if (content == "") {
+        alert("내용을 입력하세요");
+        return
     }
     $.ajax({
         type: "POST",


### PR DESCRIPTION
- 댓글 작성 시 공백을 입력하고 작성 버튼을 누르면 경고창이 나오면서 해당 동작을 막음.
- 글자 수 제한 기능을 추가 
   - 글자 수 제한으로 하면 한글과 알파벳의 바이트 수가 다르기 때문에 글자 수 제한의 의미가 무의미해지기 때문에 byte 단위로 제한을 검.


Fixed: #75 
