### PR TITLE
프로필 페이지에서 해당 프로필의 북마크가 나오도록 수정

### DIFF
--- a/static/js/profile_about.js
+++ b/static/js/profile_about.js
@@ -328,8 +328,7 @@ function toggleTab(type) {
 	let $li_tab = $(`#${type}`)
 	if (`${type}`=="posts") {
 		$li_tab.addClass("is-active").siblings().removeClass("is-active")
-		let userName = localStorage.getItem("IllllIlIII_hid")
-		getBookmark(userName)
+		getBookmark(profileUser)
 	} else if (`${type}`=="comments") {
 		$li_tab.addClass("is-active").siblings().removeClass("is-active")
 		getComments();


### PR DESCRIPTION
[Fix]
프로필 페이지에서 로그인한 사용자의 북마크 기사가 아니라, 해당 프로필의 사용자가 북마크한 기사가 나오도록 수정

Fixed: #81

---
이슈 번호 수정을 위한 재pr입니다