### PR TITLE
Fix: profileurl을 가져오는 방식을 변경 

### DIFF
--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -167,28 +167,20 @@ function num2str(count) {
     return count
 }
 
+function getProfileUrl(username) {
+    let profileUrl = $.ajax({
+        async: false,
+        url: `/user/profile/pic/${username}`,
+        type: "GET",
+        dataType: "text"
+    }).responseText;
+    return profileUrl;
+}
 
 // 댓글 리스팅
 function getComments() {
     let newsId = getNewsId();
     $("#comment-box").empty();
-
-    let currentLoginUserName = $.ajax({
-        async: false,
-        url: "/api/user/me",
-        type: "GET",
-        dataType: "text"
-    }).responseText;
-
-    function getProfileUrl(username) {
-        let profileUrl = $.ajax({
-            async: false,
-            url: `/user/profile/pic/${username}`,
-            type: "GET",
-            dataType: "text"
-        }).responseText;
-        return profileUrl;
-    }
 
     $.ajax({
         type: "GET",
@@ -257,20 +249,6 @@ function getSortedComments(direction) {
     let newsId = getNewsId();
     $("#comment-box").empty()
 
-    let currentLoginUserName = $.ajax({
-        async: false,
-        url: "/api/user/me",
-        type: "GET",
-        dataType: "text"
-    }).responseText;
-
-    let profileUrl = $.ajax({
-        async: false,
-        url: `/user/profile/pic/${currentLoginUserName}`,
-        type: "GET",
-        dataType: "text"
-    }).responseText;
-
     $.ajax({
         type: "GET",
         url: `/api/user/comments/sort/${newsId}?direction=${direction}`,
@@ -283,7 +261,7 @@ function getSortedComments(direction) {
                 let content = comment.content;
                 let username = comment.profileResponseDto.username;
                 let nickname = comment.profileResponseDto.nickname;
-                let profilePicLink = comment.profileResponseDto.profile_pic == "default" ? "/static/profile_pics/profile_placeholder.png" : profileUrl;
+                let profilePicLink = comment.profileResponseDto.profile_pic == "default" ? "/static/profile_pics/profile_placeholder.png" : getProfileUrl(username);
                 addHTML(commentId, time, content, username, nickname, profilePicLink);
             }
         }

--- a/static/js/detail.js
+++ b/static/js/detail.js
@@ -180,12 +180,15 @@ function getComments() {
         dataType: "text"
     }).responseText;
 
-    let profileUrl = $.ajax({
-        async: false,
-        url: `/user/profile/pic/${currentLoginUserName}`,
-        type: "GET",
-        dataType: "text"
-    }).responseText;
+    function getProfileUrl(username) {
+        let profileUrl = $.ajax({
+            async: false,
+            url: `/user/profile/pic/${username}`,
+            type: "GET",
+            dataType: "text"
+        }).responseText;
+        return profileUrl;
+    }
 
     $.ajax({
         type: "GET",
@@ -199,7 +202,7 @@ function getComments() {
                 let content = comment.content;
                 let username = comment.profileResponseDto.username;
                 let nickname = comment.profileResponseDto.nickname;
-                let profilePicLink = comment.profileResponseDto.profile_pic == "default" ? "/static/profile_pics/profile_placeholder.png" : profileUrl;
+                let profilePicLink = comment.profileResponseDto.profile_pic == "default" ? "/static/profile_pics/profile_placeholder.png" : getProfileUrl(username);
                 addHTML(commentId, time, content, username, nickname, profilePicLink);
             }
         }


### PR DESCRIPTION
## 🎵 설명
: 댓글을 화면에 보여줄 때 기존에는 로그인한 유저의 프로필 사진을 보여주게 돼 있었는데 댓글을 작성한 유저의 프로필 사진을 보이게끔 변경.
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: 제대로 동작할 지 한 번 점검해주세요!
<br>

## 🏷 해결한 이슈 번호 
Fixed: #102 
<br>

## 📌 Merge 제목
`Merge: develop <- `브랜치명 #pr번호
