### PR TITLE
프론트앤드 코드 배포를 수행시키는 트리거를 develop에서 main브랜치로 변경

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: NewsCommunity -fFinal2
 on:
   push:
     branches:
-      - develop
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🎵 설명
: 백앤드 CI/CD의 배포 방식에 맞춰 프론트앤드도 main을 통한 배포로 변경 필요, main.yml에서 타겟 브랜치의 이름을 develop에서 main으로 변경
<br>

## ✅ Merge 하기 전 체크하셨나요?
- [x] 브랜치 이름에 이슈번호가 잘 있나요? 없다면 Merge commit 할 때 써주기!
- [x] Merge commit 설명란에는 커밋 번호를 넣어주세요!

<br>

## 😀 팀원이 신경써서 봐줬으면 하는 부분
: 프론트앤드가 배포되는 흐름, 개발하는 위치
<br>

## 🏷 해결한 이슈 번호 
Fixed: #164 
<br>

## 📌 Merge 제목
`Merge: develop <- `164/fix_deploy-trigger-branch #165
